### PR TITLE
Hotfix - Global Breakpoints

### DIFF
--- a/src/global/global.js
+++ b/src/global/global.js
@@ -25,6 +25,9 @@ export default function() {
       if (
         rule.selectorText
         && rule.selectorText.trim() === ':root'
+        && rule.style.getPropertyValue('--breakpoint--mobile')
+        && rule.style.getPropertyValue('--breakpoint--tablet')
+        && rule.style.getPropertyValue('--breakpoint--desktop')
       ) {
         let breakpoints = {
           'mobile': JSON.parse(rule.style.getPropertyValue('--breakpoint--mobile')),


### PR DESCRIPTION
Ensure that the breakpoint properties are present before attempting to run a JSON parse